### PR TITLE
Add pipectl Homebrew Formula

### DIFF
--- a/Formula/pipectl.rb
+++ b/Formula/pipectl.rb
@@ -1,0 +1,51 @@
+# typed: false
+# frozen_string_literal: true
+
+class Pipectl < Formula
+    desc "pipectl: A Command Line Tool for PipeCD."
+    homepage "https://github.com/pipe-cd/pipecd"
+    version "0.47.0"
+    license "Apache-2.0"
+
+    on_macos do
+        if Hardware::CPU.intel?
+            url "https://github.com/pipe-cd/pipecd/releases/download/v0.47.0/pipectl_v0.47.0_darwin_amd64"
+            sha256 "922a7e4cd4e3c79e4ce9c16bfbe7849493691cf0b8a4be6874c3c3bb341efabc"
+
+            def install
+                bin.install "pipectl_v0.47.0_darwin_amd64" => "pipectl"
+            end
+        end
+        if Hardware::CPU.arm?
+            url "https://github.com/pipe-cd/pipecd/releases/download/v0.47.0/pipectl_v0.47.0_darwin_arm64"
+            sha256 "b3c3efcd4b4b1a611e320ebd7613705f919ae793167f8f40a22826431b9d6c5f"
+
+            def install
+                bin.install "pipectl_v0.47.0_darwin_arm64" => "pipectl"
+            end
+        end
+    end
+
+    on_linux do
+        if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+            url "https://github.com/pipe-cd/pipecd/releases/download/v0.47.0/pipectl_v0.47.0_linux_arm64"
+            sha256 "cca096cfff8ea95a908eb69f1bf6e7abbabb7cb0d3de4e5763f0b438c8a34a95"
+
+            def install
+                bin.install "pipectl_v0.47.0_linux_arm64" => "pipectl"
+            end
+        end
+        if Hardware::CPU.intel?
+            url "https://github.com/pipe-cd/pipecd/releases/download/v0.47.0/pipectl_v0.47.0_linux_amd64"
+            sha256 "58bd709010df521f378d8290f3317424472bb6494d7748b1bb4740fea5db4d7f"
+
+            def install
+                bin.install "pipectl_v0.47.0_linux_amd64" => "pipectl"
+            end
+        end
+    end
+
+    test do
+        system "#{bin}/pipectl --help"
+    end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request introduces support for installing the `pipectl` command-line tool using Homebrew. This is a significant change as it simplifies the installation process for users on macOS and Linux.

ref.

- https://brew.sh/
- https://docs.brew.sh/Taps
- https://docs.brew.sh/License-Guidelines
- https://docs.brew.sh/Homebrew-on-Linux

For more details:

* `Formula/pipectl.rb`: A new Homebrew formula for `pipectl` was added. This formula provides the instructions for Homebrew to install `pipectl`, including the URLs for the `pipectl` binaries for both macOS and Linux and their corresponding SHA256 hashes. The formula also includes a test to ensure `pipectl` was installed correctly.
* For each new release, we need to update this version, all the text 0.47.0 in this file, and for each sha256. Although this process can be automated, it is beyond the scope of this PR.

**Which issue(s) this PR fixes**:

Related:

- https://github.com/pipe-cd/pipecd/issues/4879
- https://github.com/pipe-cd/pipecd/pull/4880

**Does this PR introduce a user-facing change?**:

No.
